### PR TITLE
Improve performance

### DIFF
--- a/src/datascript_chat/react.cljs
+++ b/src/datascript_chat/react.cljs
@@ -11,11 +11,18 @@
   (let [react-component
         (.createClass js/React
            #js {:getInitialState (fn [] (atom {}))
+                :shouldComponentUpdate
+                (fn [next-props _]
+                  (this-as this
+                           (not= (aget (.-props this) "value")
+                                 (aget next-props "value"))))
                 :render
                 (fn []
                   (this-as this
                     (binding [*component* this]
-                      (apply renderer (aget (.-props this) "args")))))
+                      (apply renderer
+                             (aget (.-props this) "value")
+                             (aget (.-props this) "statics")))))
                 :componentWillUpdate
                 (fn [_ _]
                   (when will-update
@@ -29,8 +36,8 @@
                       (binding [*component* this]
                         (did-update (node))))))
                 })]
-    (fn [& args]
-      (react-component #js {:args args}))))
+    (fn [value & statics]
+      (react-component #js {:value value :statics statics}))))
 
 (defn render [component node]
   (.renderComponent js/React component node))

--- a/src/datascript_chat/ui.cljs
+++ b/src/datascript_chat/ui.cljs
@@ -15,7 +15,7 @@
   (goog.string/format "%02d:%02d" (.getHours date) (.getMinutes date)))
 
 (defn- should-scroll? [node]
-  (<= 
+  (<=
     (- (.-scrollHeight node) (.-scrollTop node) (.-offsetHeight node))
     0))
 
@@ -34,7 +34,7 @@
   [:.message__avatar
     [:img {:src (:user/avatar user "web/avatars/loading.jpg")}]])
 
-(r/defc room [room last-msg unread event-bus]
+(r/defc room [{:keys [room last-msg unread]} event-bus]
   (let [user (:message/author last-msg)]
     [:.topic { :class    (when (:room/selected room) "topic_selected")
                :on-click (fn [_]
@@ -54,26 +54,11 @@
             ])
         [:.topic__title (:room/title room)])]))
 
-(r/defc rooms-pane [db event-bus]
-  (let [rooms         (->> (u/qes-by db :room/title)
-                           (sort-by :room/title))
-        last-msgs     (u/qmap '[:find  ?r (max ?m)
-                                :where [?m :message/room ?r]]
-                                db)
-        unread-counts (u/qmap '[:find ?r (count ?m)
-                                :where [?m :message/unread]
-                                       [?m :message/room ?r]]
-                                db)]
-    [:#rooms__pane.pane
-      [:#rooms__header.header
-        [:.title "Rooms"]]
-      (map #(let [rid (:db/id %)]
-              (room %
-                    (when-let [mid (get last-msgs rid)]
-                      (d/entity db mid))
-                    (get unread-counts rid)
-                    event-bus))
-           rooms)]))
+(r/defc rooms-pane [rooms event-bus]
+  [:#rooms__pane.pane
+   [:#rooms__header.header
+    [:.title "Rooms"]]
+   (map #(room % event-bus) rooms)])
 
 (r/defc text [text]
   [:.message__text
@@ -90,19 +75,12 @@
         [:span.message__ts
           (format-time (:message/timestamp msg))]]
       (text (:message/text msg))]))
-     
-(r/defc chat-pane [db]
-  (let [[room-id room-title]
-            (->> (d/q '[:find ?r ?t
-                        :where [?r :room/selected true]
-                               [?r :room/title ?t]] db)
-                    first)
-        msgs (->> (u/qes-by db :message/room room-id)
-                  (sort-by :message/timestamp))]
-    [:#chat__pane.pane
-      [:#chat__header.header
-        [:.title room-title]]
-        (map message msgs)])
+
+(r/defc chat-pane [{:keys [room-id room-title msgs]}]
+  [:#chat__pane.pane
+   [:#chat__header.header
+    [:.title room-title]]
+   (map message msgs)]
   :will-update (fn [node]
                  (r/remember :sticky? (should-scroll? node)))
   :did-update  (fn [node]
@@ -118,21 +96,49 @@
         (set! (.. e -target -value) "")
         (.preventDefault e)))))
 
-(r/defc compose-pane [db event-bus]
+(r/defc compose-pane [{:keys [user]} event-bus]
   [:#compose
-    (avatar (u/qe-by db :user/me true))
+    (avatar user)
     [:textarea#compose__area.message__text
       { :placeholder "Reply..."
         :auto-focus  true
         :on-key-down  (textarea-keydown #(send-msg event-bus %)) }]])
 
-(r/defc window [db event-bus]
+(r/defc window [{:keys [rooms chat compose]} event-bus]
   [:#window
-    [:#rooms (rooms-pane db event-bus)]
-    [:#chat  (chat-pane db)]
-    (compose-pane db event-bus)])
+    [:#rooms (rooms-pane rooms event-bus)]
+    [:#chat  (chat-pane chat)]
+    (compose-pane compose event-bus)])
 
 ;; RENDER MACHINERY
+
+(defn- prepare-ui [db]
+  {:rooms (let [rooms (->> (u/qes-by db :room/title)
+                           (sort-by :room/title))
+                last-msgs (u/qmap '[:find  ?r (max ?m)
+                                    :where [?m :message/room ?r]]
+                                  db)
+                unread-counts (u/qmap '[:find ?r (count ?m)
+                                        :where [?m :message/unread]
+                                        [?m :message/room ?r]]
+                                      db)]
+            (for [{rid :db/id :as room} rooms]
+              {:room room
+               :last-msg (when-let [mid (get last-msgs rid)]
+                           (d/entity db mid))
+               :unread (get unread-counts rid)}))
+   :chat (let [[room-id room-title]
+               (->> (d/q '[:find ?r ?t
+                           :where [?r :room/selected true]
+                           [?r :room/title ?t]] db)
+                    first)
+               msgs (->> (u/qes-by db :message/room room-id)
+                         (sort-by :message/timestamp))]
+           {:room-id room-id
+            :room-title room-title
+            :msgs msgs})
+   :compose {:user (u/qe-by db :user/me true)}})
+
 
 (def ^:dynamic *debug-render* true)
 
@@ -145,7 +151,10 @@
   (if *debug-render*
     (let [key (str "Render (" (count (:eavt db)) " datoms)")]
       (.time js/console key)
-      (r/render (window db event-bus) (.-body js/document))
+      (-> db
+          (prepare-ui)
+          (window event-bus)
+          (r/render (.-body js/document)))
       (.timeEnd js/console key))
     (r/render (window db event-bus) (.-body js/document))))
 


### PR DESCRIPTION
By adhering to shouldComponentUpdate rendering time is consistently cut
by X2 X2.5. The trick is not to pass the entire db to the component but
to abstract the model via a ui data structure optimised for rendering.

Has the side benefit of removing some query clutter from the components.
